### PR TITLE
Add dark theme and optimize state management

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'package:flutter/material.dart';
 
 import 'models.dart';
@@ -7,11 +8,20 @@ class AppState extends ChangeNotifier {
   final Repo repo;
   AppState(this.repo) {
     clientes = repo.loadClientes();
+    _atualizarNomesExistentes();
+    themeMode = repo.themeMode;
   }
 
   List<Cliente> clientes = [];
+  late ThemeMode themeMode;
 
-  List<String> get nomesExistentes => clientes.map((e) => e.nome).toList()..sort();
+  List<String> _nomesExistentes = [];
+  UnmodifiableListView<String> get nomesExistentes =>
+      UnmodifiableListView(_nomesExistentes);
+
+  void _atualizarNomesExistentes() {
+    _nomesExistentes = clientes.map((e) => e.nome).toList()..sort();
+  }
 
   bool existeNome(String nome) =>
       clientes.any((c) => c.nome.toLowerCase().trim() == nome.toLowerCase().trim());
@@ -37,6 +47,7 @@ class AppState extends ChangeNotifier {
       precoUnitario: precoUnitario,
     ));
     await repo.saveClientes(clientes);
+    _atualizarNomesExistentes();
     notifyListeners();
   }
 
@@ -61,11 +72,18 @@ class AppState extends ChangeNotifier {
   Future<void> removerCliente(Cliente c) async {
     clientes.removeWhere((x) => x.id == c.id);
     await repo.saveClientes(clientes);
+    _atualizarNomesExistentes();
     notifyListeners();
   }
 
   Future<void> editarPix({required String key, required String nome}) async {
     await repo.setPix(key: key, nome: nome);
+    notifyListeners();
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    themeMode = mode;
+    await repo.setThemeMode(mode);
     notifyListeners();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,13 +18,24 @@ class DevedoresApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Devedores',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.brown),
-        useMaterial3: true,
-      ),
-      home: HomePage(app: appState),
+    return AnimatedBuilder(
+      animation: appState,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'Devedores',
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.brown),
+            useMaterial3: true,
+          ),
+          darkTheme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.brown, brightness: Brightness.dark),
+            useMaterial3: true,
+          ),
+          themeMode: appState.themeMode,
+          home: HomePage(app: appState),
+        );
+      },
     );
   }
 }

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -14,12 +14,14 @@ class _SettingsPageState extends State<SettingsPage> {
   final _form = GlobalKey<FormState>();
   late final TextEditingController _pixKey;
   late final TextEditingController _pixNome;
+  bool _darkMode = false;
 
   @override
   void initState() {
     super.initState();
     _pixKey = TextEditingController(text: widget.app.pixKey);
     _pixNome = TextEditingController(text: widget.app.pixNome);
+    _darkMode = widget.app.themeMode == ThemeMode.dark;
   }
 
   @override
@@ -32,6 +34,12 @@ class _SettingsPageState extends State<SettingsPage> {
           key: _form,
           child: Column(
             children: [
+              SwitchListTile(
+                title: const Text('Tema escuro'),
+                value: _darkMode,
+                onChanged: (v) => setState(() => _darkMode = v),
+              ),
+              const SizedBox(height: 8),
               TextFormField(
                 controller: _pixNome,
                 decoration:
@@ -54,6 +62,8 @@ class _SettingsPageState extends State<SettingsPage> {
                   if (!_form.currentState!.validate()) return;
                   await widget.app.editarPix(
                       key: _pixKey.text.trim(), nome: _pixNome.text.trim());
+                  await widget.app
+                      .setThemeMode(_darkMode ? ThemeMode.dark : ThemeMode.light);
                   if (!mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Configurações salvas.')));

--- a/lib/repository.dart
+++ b/lib/repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'models.dart';
@@ -7,6 +8,7 @@ class Repo {
   static const _kClientes = 'clientes_v1';
   static const _kPixKey = 'pix_key';
   static const _kPixNome = 'pix_nome';
+  static const _kThemeMode = 'theme_mode';
 
   final SharedPreferences prefs;
   Repo(this.prefs);
@@ -25,9 +27,15 @@ class Repo {
 
   String get pixKey => prefs.getString(_kPixKey) ?? '';
   String get pixNome => prefs.getString(_kPixNome) ?? '';
+  ThemeMode get themeMode =>
+      ThemeMode.values[prefs.getInt(_kThemeMode) ?? ThemeMode.light.index];
 
   Future<void> setPix({required String key, required String nome}) async {
     await prefs.setString(_kPixKey, key);
     await prefs.setString(_kPixNome, nome);
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    await prefs.setInt(_kThemeMode, mode.index);
   }
 }


### PR DESCRIPTION
## Summary
- Add dark theme with runtime toggle and persistence
- Cache client name suggestions and expose theme mode in app state
- Add settings toggle for dark theme and store preference

## Testing
- `apt-get update`
- `dart format lib`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68c770fea60083319be5fe1c84cc9380